### PR TITLE
chore(rebrand): metadata & NOTICE (no code changes)

### DIFF
--- a/NOTICE.md
+++ b/NOTICE.md
@@ -1,0 +1,9 @@
+# NOTICE
+
+This repository is an **independent fork** of upstream Uniswap code and is **not affiliated with or endorsed by Uniswap**.
+
+- Upstream source: git@github.com:Uniswap/universal-router.git
+- Copyrights and licenses remain with their respective owners.
+- See `LICENSE` for full licensing terms of this repository. Some upstream components may be under different licenses; consult upstream for details.
+
+This fork primarily changes branding and build/release metadata at this stage. Functional changes (if any) will be documented in release notes and pull requests.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+> **Independent fork** — not affiliated with Uniswap. See NOTICE.md.
+
 # Universal Router
 
 Please read the [Contributions](https://github.com/Uniswap/universal-router#contributions) section before submitting a Pull Request.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniswap/universal-router",
-  "description": "Smart contracts for Universal Router",
+  "description": "Primea fork — independent fork of upstream Uniswap repo",
   "license": "GPL-2.0-or-later",
   "publishConfig": {
     "access": "public",
@@ -15,7 +15,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/Uniswap/universal-router"
+    "url": "git+ssh://git@github.com/primeanetwork/universal-router.git"
   },
   "files": [
     "contracts/base",
@@ -69,5 +69,9 @@
     "prettier:fix": "prettier --write '**/*.ts' && prettier --write '**/*.json'",
     "lint": "yarn prettier:fix && forge fmt",
     "lint:check": "prettier --check '**/*.ts' && forge fmt --check"
-  }
+  },
+  "bugs": {
+    "url": "https://github.com/primeanetwork/universal-router/issues"
+  },
+  "homepage": "https://github.com/primeanetwork/universal-router#readme"
 }


### PR DESCRIPTION
Adds `NOTICE.md`, injects an in-repo banner in `README.md`, and updates `package.json` metadata fields to point to `primeanetwork/universal-router`. **No product code changes.**